### PR TITLE
Add .gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Crawler history file
+crawler_history.json
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Logs and local data
+*.log
+
+# Testing and coverage
+.pytest_cache/
+.coverage
+.tox/
+.nox/
+.mypy_cache/
+
+# IDE and editor settings
+.vscode/
+.idea/
+
+# Streamlit cache
+.streamlit/cache/
+
+# OS-generated files
+.DS_Store


### PR DESCRIPTION
## Summary
- add `.gitignore` to filter Python caches and Streamlit cache files

## Testing
- `python -m py_compile wheres_my_value.py wheres_my_value_streamlit.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420cc88e5483228882c99a86043586