### PR TITLE
Expose crawler via FastAPI

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,42 @@
+from typing import List, Optional, Dict, Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from wheres_my_value import CrawlerConfig, run_crawl
+
+app = FastAPI()
+
+class CrawlRequest(BaseModel):
+    base_url: str
+    search_values: List[str]
+    sleep_time: float = 2.0
+    timeout: float = 10.0
+    max_pages: int = 100
+    max_depth: int = 5
+    max_workers: int = 1
+    verbose: bool = False
+    export_results: bool = False
+    respect_robots: bool = True
+    use_history: bool = False
+    history_file: Optional[str] = None
+
+
+@app.post("/crawl")
+def crawl_endpoint(config: CrawlRequest) -> Dict[str, Any]:
+    crawler_config = CrawlerConfig(
+        base_url=config.base_url,
+        search_values=config.search_values,
+        sleep_time=config.sleep_time,
+        timeout=config.timeout,
+        max_pages=config.max_pages,
+        max_depth=config.max_depth,
+        max_workers=config.max_workers,
+        verbose=config.verbose,
+        export_results=config.export_results,
+        respect_robots=config.respect_robots,
+        use_history=config.use_history,
+        history_file=config.history_file,
+    )
+
+    return run_crawl(crawler_config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ beautifulsoup4>=4.12.0
 urllib3>=2.0.0
 python-dateutil>=2.8.2
 typing-extensions>=4.5.0
+fastapi>=0.100.0
+uvicorn>=0.23.0

--- a/wheres_my_value.py
+++ b/wheres_my_value.py
@@ -731,6 +731,33 @@ def get_user_input() -> CrawlerConfig:
         history_file=history_file
     )
 
+
+def run_crawl(config: CrawlerConfig) -> Dict[str, List[Dict[str, str]]]:
+    """Run the crawler and return JSON serializable results."""
+    crawler = WebCrawler(config)
+
+    searches: List[Tuple[str, str]] = []
+    for value in config.search_values:
+        searches.extend([
+            ("text", value),
+            ("id", value),
+            ("class", value),
+            ("attr", value),
+        ])
+
+    raw_results = crawler.crawl_and_search(searches)
+
+    serialized: Dict[str, List[Dict[str, str]]] = {}
+    for key, items in raw_results.items():
+        serialized[key] = []
+        for url, element in items:
+            if isinstance(element, NavigableString):
+                text = str(element).strip()
+            else:
+                text = element.get_text(strip=True)
+            serialized[key].append({"url": url, "text": text})
+    return serialized
+
 def main() -> None:
     config = get_user_input()
     crawler = WebCrawler(config)


### PR DESCRIPTION
## Summary
- add `run_crawl` helper for programmatic use
- create `api/server.py` FastAPI server with `/crawl` endpoint
- expose FastAPI and uvicorn dependencies

## Testing
- `python -m py_compile wheres_my_value.py api/server.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68491e419c7083228182db6887faba71