### PR TITLE
Add FastAPI server and web form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ crawler_history.json
 venv/
 ENV/
 env/
+node_modules/
 
 # Distribution / packaging
 build/

--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ Export results to a file? [y/N]: y
 ```
 
 
+## Starting the Web Server
+
+Run the API server and open the UI:
+
+```bash
+uvicorn server:app --reload
+```
+
+Visit `http://localhost:8000` in your browser to use the form interface.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ beautifulsoup4>=4.12.0
 fastapi>=0.110.0
 python-dateutil>=2.8.2
 requests>=2.31.0
+typing-extensions>=4.5.0
 urllib3>=2.0.0
 uvicorn>=0.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-requests>=2.31.0
 beautifulsoup4>=4.12.0
-urllib3>=2.0.0
+fastapi>=0.110.0
 python-dateutil>=2.8.2
-typing-extensions>=4.5.0
+requests>=2.31.0
+urllib3>=2.0.0
+uvicorn>=0.29.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,64 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, HttpUrl
+from typing import List, Optional
+
+from wheres_my_value import WebCrawler, CrawlerConfig
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.get("/")
+def read_index() -> FileResponse:
+    """Serve the main HTML page."""
+    return FileResponse("static/index.html")
+
+class CrawlRequest(BaseModel):
+    base_url: HttpUrl
+    search_values: List[str]
+    max_pages: Optional[int] = 100
+
+class CrawlResult(BaseModel):
+    found_values: List[str]
+    pages_visited: int
+    errors: int
+
+@app.post('/crawl', response_model=CrawlResult)
+def crawl(request: CrawlRequest):
+    config = CrawlerConfig(
+        base_url=str(request.base_url),
+        search_values=request.search_values,
+        sleep_time=1.0,
+        timeout=10.0,
+        max_pages=request.max_pages or 100,
+        max_depth=5,
+        max_workers=1,
+        verbose=False,
+        export_results=False,
+        respect_robots=True,
+        use_history=False,
+        history_file=None,
+    )
+
+    crawler = WebCrawler(config)
+    searches = []
+    for val in config.search_values:
+        searches.extend([
+            ('text', val),
+            ('id', val),
+            ('class', val),
+            ('attr', val),
+        ])
+
+    try:
+        results = crawler.crawl_and_search(searches)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return CrawlResult(
+        found_values=sorted(list(crawler.found_values)),
+        pages_visited=crawler.stats.pages_visited,
+        errors=crawler.stats.error_count,
+    )

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Where's My Value?</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        #loading { display: none; }
+        #result { margin-top: 1rem; }
+    </style>
+</head>
+<body>
+    <h1>Where's My Value?</h1>
+    <form id="crawl-form">
+        <label>
+            Base URL:
+            <input type="url" id="base-url" required placeholder="https://example.com" />
+        </label>
+        <br/>
+        <label>
+            Search values (comma separated):
+            <input type="text" id="search-values" required />
+        </label>
+        <br/>
+        <button type="submit">Start Crawl</button>
+    </form>
+    <div id="loading">Loading...</div>
+    <pre id="result"></pre>
+
+    <script>
+        const form = document.getElementById('crawl-form');
+        const loading = document.getElementById('loading');
+        const result = document.getElementById('result');
+
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            result.textContent = '';
+            loading.style.display = 'block';
+
+            const baseUrl = document.getElementById('base-url').value;
+            const values = document.getElementById('search-values').value
+                .split(',')
+                .map(v => v.trim())
+                .filter(Boolean);
+
+            try {
+                const response = await fetch('/crawl', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ base_url: baseUrl, search_values: values })
+                });
+
+                if (!response.ok) {
+                    const error = await response.text();
+                    throw new Error(error);
+                }
+
+                const data = await response.json();
+                const summary = [
+                    `Pages visited: ${data.pages_visited}`,
+                    `Errors: ${data.errors}`,
+                    `Found values: ${data.found_values.join(', ')}`
+                ].join('\n');
+                result.textContent = summary;
+            } catch (err) {
+                result.textContent = err.message;
+            } finally {
+                loading.style.display = 'none';
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement simple FastAPI API with `/crawl` endpoint
- serve a minimal HTML form
- document how to start the web server
- add FastAPI and uvicorn dependencies
- fix routing so `/crawl` works with static files
- show a concise summary on completion
- clean up requirements list

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile server.py wheres_my_value.py`
- `python -c "import server; print('loaded', server.app.title)"`


------
https://chatgpt.com/codex/tasks/task_e_68491dfa178c83229f9f7d4c0f61969c