### PR TITLE
Update devcontainer and docs for Node.js

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,11 @@
   "name": "Python 3",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
   "customizations": {
     "codespaces": {
       "openFiles": [

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ dist/
 # IDE and editor settings
 .vscode/
 .idea/
+# Node and Next.js artifacts
+node_modules/
+.next/
 # OS-generated files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -34,4 +34,18 @@ Track visited URL history? [y/N]: y
 Export results to a file? [y/N]: y
 ```
 
+## Running the Development Servers
+
+Start the FastAPI server:
+
+```bash
+uvicorn api.server:app
+```
+
+Start the Next.js dev server:
+
+```bash
+npm run dev
+```
+
 


### PR DESCRIPTION
## Summary
- install Node.js in the dev container
- ignore Next.js build output
- document running FastAPI and Next.js servers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68491dfc208083228627270885828f73