### PR TITLE
Add Next.js defaults

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,24 @@
+# UI Development
+
+This folder contains the Next.js application for the project.
+
+## Getting Started
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The app expects an API server running locally on port `8000`. To target a different server, set the `NEXT_PUBLIC_API_BASE_URL` environment variable.
+
+## Building for Production
+
+Create an optimized build with:
+
+```bash
+npm run build
+```
+
+The resulting output will be placed in the `.next` directory.

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,0 +1,12 @@
+import type { NextConfig } from 'next'
+import path from 'path'
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  webpack(config) {
+    config.resolve.alias['@'] = path.resolve(__dirname, 'src')
+    return config
+  },
+}
+
+export default nextConfig

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add `next.config.ts` with strict mode and webpack alias
- document build steps and env var in `ui/README.md`
- configure path mapping in `ui/tsconfig.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7d3adb188322bfcae3b39fd0ac95