### PR TITLE
Enhance Tailwind config

### DIFF
--- a/ui/postcss.config.mjs
+++ b/ui/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './src/**/*.{ts,tsx}',
+    './app/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config


### PR DESCRIPTION
## Summary
- extend Tailwind `content` paths to match standard Next.js usage

## Testing
- `npx tailwindcss init -p` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684b7d2ae89c83228f57d8221262b1af