### PR TITLE
Add FastAPI server and modular crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,14 @@ Track visited URL history? [y/N]: y
 Export results to a file? [y/N]: y
 ```
 
+## Running the API Server
+
+Start a FastAPI server exposing the `/crawl` endpoint:
+
+```bash
+uvicorn api.server:app --reload
+```
+
+Send a `POST` request with the crawler configuration to `/crawl` to perform a crawl. The results are returned as JSON.
+
 

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from wheres_my_value import CrawlerConfig, run_crawler, element_to_string
+
+app = FastAPI()
+
+
+class CrawlerRequest(BaseModel):
+    base_url: str
+    search_values: List[str]
+    sleep_time: float = 2.0
+    timeout: float = 10.0
+    max_pages: int = 100
+    max_depth: int = 5
+    max_workers: int = 1
+    verbose: bool = False
+    export_results: bool = False
+    respect_robots: bool = True
+    use_history: bool = False
+    history_file: Optional[str] = None
+
+
+@app.post("/crawl")
+def crawl(config: CrawlerRequest) -> Dict[str, Any]:
+    crawler_config = CrawlerConfig(**config.dict())
+    results = run_crawler(crawler_config)
+
+    serialized: Dict[str, List[Dict[str, str]]] = {}
+    for key, values in results.items():
+        serialized[key] = [
+            {"url": url, "element": element_to_string(element)}
+            for url, element in values
+        ]
+
+    return {"results": serialized}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ beautifulsoup4>=4.12.0
 urllib3>=2.0.0
 python-dateutil>=2.8.2
 typing-extensions>=4.5.0
+fastapi>=0.110.0
+uvicorn>=0.22.0


### PR DESCRIPTION
## Summary
- refactor crawler into callable `run_crawler`
- expose FastAPI endpoint in `api/server.py`
- serialize crawl results for JSON API
- document how to run the API server
- include FastAPI and Uvicorn in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile wheres_my_value.py api/server.py`


------
https://chatgpt.com/codex/tasks/task_e_68491e12b390832286f476eec33e2801