### PR TITLE
Add FastAPI server and API refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,14 @@ Track visited URL history? [y/N]: y
 Export results to a file? [y/N]: y
 ```
 
+## Running the API Server
+
+Launch the FastAPI server to crawl via HTTP:
+
+```bash
+uvicorn api.server:app --reload
+```
+
+Send a `POST` request to `/crawl` with the same fields as `CrawlerConfig`.
+
 

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+
+from wheres_my_value import CrawlerConfig, crawl_with_config
+
+app = FastAPI()
+
+class CrawlerConfigModel(BaseModel):
+    base_url: str
+    search_values: List[str]
+    sleep_time: float = 2.0
+    timeout: float = 10.0
+    max_pages: int = 100
+    max_depth: int = 5
+    max_workers: int = 1
+    verbose: bool = False
+    export_results: bool = False
+    respect_robots: bool = True
+    use_history: bool = False
+    history_file: Optional[str] = None
+
+
+def serialize_results(results: Dict[str, List[tuple]]) -> Dict[str, List[Dict[str, Any]]]:
+    serialized: Dict[str, List[Dict[str, Any]]] = {}
+    for key, matches in results.items():
+        search_type, value = key.split(":", 1)
+        for url, element in matches:
+            text = element.get_text(strip=True) if hasattr(element, "get_text") else str(element).strip()
+            serialized.setdefault(value, []).append({
+                "search_type": search_type,
+                "url": url,
+                "text": text,
+            })
+    return serialized
+
+
+@app.post("/crawl")
+async def crawl(config: CrawlerConfigModel):
+    crawler_config = CrawlerConfig(**config.model_dump())
+    results, _ = crawl_with_config(crawler_config)
+    return serialize_results(results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ beautifulsoup4>=4.12.0
 urllib3>=2.0.0
 python-dateutil>=2.8.2
 typing-extensions>=4.5.0
+fastapi>=0.110.0
+uvicorn>=0.27.1

--- a/wheres_my_value.py
+++ b/wheres_my_value.py
@@ -731,18 +731,27 @@ def get_user_input() -> CrawlerConfig:
         history_file=history_file
     )
 
-def main() -> None:
-    config = get_user_input()
+def crawl_with_config(
+    config: CrawlerConfig,
+) -> Tuple[Dict[str, List[Tuple[str, Any]]], WebCrawler]:
+    """Run the crawler and return the results alongside the crawler instance."""
     crawler = WebCrawler(config)
-    
-    searches = []
+
+    searches: List[Tuple[str, str]] = []
     for search_value in config.search_values:
         searches.extend([
-            ('text', search_value),
-            ('id', search_value),
-            ('class', search_value),
-            ('attr', search_value)
+            ("text", search_value),
+            ("id", search_value),
+            ("class", search_value),
+            ("attr", search_value),
         ])
+
+    results = crawler.crawl_and_search(searches)
+    return results, crawler
+
+
+def main() -> None:
+    config = get_user_input()
     
     print("\n=== Crawler Configuration ===")
     print(f"URL: {config.base_url}")
@@ -765,7 +774,7 @@ def main() -> None:
     print("\nPress Ctrl+C to stop at any time")
     
     try:
-        results = crawler.crawl_and_search(searches)
+        results, crawler = crawl_with_config(config)
         
         print("\n=== Search Results ===")
         for search_value in config.search_values:


### PR DESCRIPTION
## Summary
- expose a FastAPI server in `api/server.py`
- add helper `crawl_with_config` to run crawler from other modules
- document new API usage
- install FastAPI and uvicorn

## Testing
- `python -m pip install -r requirements.txt`
- `python - <<'PY'
import api.server
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68491e2469bc832288e18fd2e8870ad1