### PR TITLE
Add API endpoint test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ typing-extensions>=4.5.0
 urllib3>=2.0.0
 uvicorn>=0.29.0
 pytest>=8.0.0
+
+httpx>=0.28.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server
+
+class DummyCrawler:
+    def __init__(self, config):
+        self.config = config
+        self.stats = type("Stats", (), {"pages_visited": 1, "error_count": 0})()
+        self.found_values = {"match"}
+
+    def crawl_and_search(self, searches):
+        return {"text:match": [(self.config.base_url, "match")]} 
+
+
+def test_crawl_endpoint(monkeypatch):
+    monkeypatch.setattr(server, "WebCrawler", DummyCrawler)
+    client = TestClient(server.app)
+    payload = {
+        "base_url": "https://example.com",
+        "search_values": ["match"],
+        "max_pages": 5
+    }
+    response = client.post("/crawl", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "found_values": ["match"],
+        "pages_visited": 1,
+        "errors": 0
+    }
+


### PR DESCRIPTION
## Summary
- test POST /crawl using FastAPI TestClient
- include httpx in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c69d5b3c08322852e0c389cb74b50