### PR TITLE
Add docstrings to server modules

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -1,3 +1,9 @@
+"""FastAPI application exposing an endpoint for running the crawler.
+
+The `/crawl` route accepts crawl parameters and returns the results produced by
+``run_crawl``.
+"""
+
 from typing import List, Optional, Dict, Any
 
 from fastapi import FastAPI

--- a/server.py
+++ b/server.py
@@ -27,6 +27,18 @@ class CrawlResult(BaseModel):
 
 @app.post('/crawl', response_model=CrawlResult)
 def crawl(request: CrawlRequest):
+    """Run a crawl job and return the summarized results.
+
+    Parameters
+    ----------
+    request: CrawlRequest
+        Crawler settings provided by the API client.
+
+    Returns
+    -------
+    CrawlResult
+        Summary of found values, pages visited and error count.
+    """
     config = CrawlerConfig(
         base_url=str(request.base_url),
         search_values=request.search_values,


### PR DESCRIPTION
## Summary
- document the FastAPI server in `api/server.py`
- describe parameters and return value for the `crawl` handler

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c69d303f0832285a96a2e18436722