### PR TITLE
Add API module for crawling

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -1,20 +1,23 @@
-"""FastAPI application exposing an endpoint for running the crawler.
+"""FastAPI server exposing an endpoint to run the crawler.
 
-The `/crawl` route accepts crawl parameters and returns the results produced by
-``run_crawl``.
+The ``/crawl`` route accepts crawler configuration fields and returns the
+results produced by :func:`run_crawl` as JSON.
 """
 
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl
 
 from wheres_my_value import CrawlerConfig, run_crawl
 
 app = FastAPI()
 
+
 class CrawlRequest(BaseModel):
-    base_url: str
+    """Parameters accepted by the ``/crawl`` endpoint."""
+
+    base_url: HttpUrl
     search_values: List[str]
     sleep_time: float = 2.0
     timeout: float = 10.0
@@ -30,19 +33,7 @@ class CrawlRequest(BaseModel):
 
 @app.post("/crawl")
 def crawl_endpoint(config: CrawlRequest) -> Dict[str, Any]:
-    crawler_config = CrawlerConfig(
-        base_url=config.base_url,
-        search_values=config.search_values,
-        sleep_time=config.sleep_time,
-        timeout=config.timeout,
-        max_pages=config.max_pages,
-        max_depth=config.max_depth,
-        max_workers=config.max_workers,
-        verbose=config.verbose,
-        export_results=config.export_results,
-        respect_robots=config.respect_robots,
-        use_history=config.use_history,
-        history_file=config.history_file,
-    )
+    """Execute the crawler with the provided configuration."""
 
+    crawler_config = CrawlerConfig(**config.model_dump())
     return run_crawl(crawler_config)


### PR DESCRIPTION
## Summary
- create `api/server.py` for FastAPI server with `/crawl`
- update tests to use the new server file

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6b65d19c8322b858ad9fc7e47004