### PR TITLE
Fix pyflakes warning in crawl endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -65,7 +65,7 @@ def crawl(request: CrawlRequest):
         ])
 
     try:
-        results = crawler.crawl_and_search(searches)
+        _ = crawler.crawl_and_search(searches)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
## Summary
- ignore result of `crawl_and_search` to prevent unused variable warning

## Testing
- `pyflakes server.py`

------
https://chatgpt.com/codex/tasks/task_e_684cbafe0ddc83228a544180bd2bca92