### PR TITLE
Fix Netlify publish path

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The repo includes `_headers` and `_redirects` for Netlify as well as a
 `.env.example` to document build-time variables.
 
 The **new** `netlify.toml` file controls the deployment. The configuration below
-builds the Next.js frontend from the `ui/` directory, outputs to `.next`, and
+builds the Next.js frontend from the `ui/` directory, outputs to `ui/.next`, and
 serves serverless functions from `netlify/functions/` using the official
 Netlify Next.js plugin:
 
@@ -95,7 +95,7 @@ Netlify Next.js plugin:
 [build]
   base    = "ui"
   command = "npm run build"
-  publish = ".next"
+  publish = "ui/.next"
 
 [functions]
   directory = "netlify/functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base   = "ui"
   command = "npm run build"
-  publish = ".next"
+  publish = "ui/.next"
 
 [functions]
   directory = "netlify/functions"


### PR DESCRIPTION
## Summary
- update Netlify publish path to `ui/.next`
- document updated path in README

## Testing
- `pytest -q`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_e_6855a94b50d4832296277400010aeffc