### PR TITLE
Implement basic crawler form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Example environment variables for local development and Netlify builds
 API_BASE_URL=http://localhost:8000
+# For Netlify deployments, set this to "/.netlify/functions/api"
 NEXT_PUBLIC_API_URL=http://localhost:8000
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
-        "@netlify/plugin-nextjs": "^5.11.2",
+        "@netlify/plugin-nextjs": "^5.11.3",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -786,9 +786,9 @@
       }
     },
     "node_modules/@netlify/plugin-nextjs": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.11.2.tgz",
-      "integrity": "sha512-9Hgd/J5nP2U/Vv0teytq9uUAGppiKV9t5tzpsuMLqeqUGD9STxXwKmyZd2v8Z4THSW9rw4+8w7dH7LVlFoym2A==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.11.3.tgz",
+      "integrity": "sha512-SCF2UPT+mDrfO3DDeUb7eTRqHycBEx4aJ8vACm17Nyn2b2ueaLlS5u/2V42SSZF/F6LydI7R78fv3xPW7HHdWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@netlify/plugin-nextjs": "^5.11.2",
+    "@netlify/plugin-nextjs": "^5.11.3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,19 +1,115 @@
+"use client";
+import { FormEvent, useState } from "react";
 import Link from "next/link";
 
+interface CrawlSummary {
+  found_values: string[];
+  pages_visited: number;
+  errors: number;
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "/.netlify/functions/api";
+
+async function fetchSummary(
+  baseUrl: string,
+  searchValues: string[],
+): Promise<CrawlSummary> {
+  const response = await fetch(`${API_BASE_URL}/crawl-summary`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ base_url: baseUrl, search_values: searchValues, max_pages: 5 }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Request failed");
+  }
+  return response.json();
+}
+
 export default function Home() {
+  const [baseUrl, setBaseUrl] = useState("");
+  const [searchValues, setSearchValues] = useState("");
+  const [summary, setSummary] = useState<CrawlSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSummary(null);
+    setError(null);
+    try {
+      setIsLoading(true);
+      const result = await fetchSummary(
+        baseUrl.trim(),
+        searchValues.split(",").map((v) => v.trim()).filter(Boolean),
+      );
+      setSummary(result);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
   return (
-    <main className="flex flex-col items-center justify-center gap-8 py-16 text-center font-sans">
-      <h1 className="text-4xl font-bold tracking-tight">Where&apos;s My Value?</h1>
-      <p className="max-w-prose text-lg text-muted-foreground">
-        Use this interface to run the crawler and inspect results in your browser. The UI is under active
-        development.
-      </p>
-      <p className="text-sm">
-        Until then you can run
-        <code className="mx-1 rounded bg-secondary px-1 py-0.5 font-mono">python wheres_my_value.py</code>
-        from the command line.
-      </p>
-      <p className="text-sm">
+    <main className="container mx-auto max-w-xl space-y-6 py-12 font-sans">
+      <h1 className="text-center text-4xl font-bold tracking-tight">Where&apos;s My Value?</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="base-url" className="mb-1 block font-medium">
+            Base URL
+          </label>
+          <input
+            id="base-url"
+            type="text"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            className="w-full rounded border px-2 py-1"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="search-values" className="mb-1 block font-medium">
+            Search values
+          </label>
+          <input
+            id="search-values"
+            type="text"
+            value={searchValues}
+            onChange={(e) => setSearchValues(e.target.value)}
+            className="w-full rounded border px-2 py-1"
+            placeholder="comma,separated,values"
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="rounded bg-primary px-4 py-2 text-primary-foreground disabled:opacity-50"
+        >
+          {isLoading ? "Crawling..." : "Crawl"}
+        </button>
+      </form>
+
+      {error && <p className="text-destructive">{error}</p>}
+      {summary && (
+        <div className="rounded border p-4">
+          <p>
+            <span className="font-medium">Pages visited:</span> {summary.pages_visited}
+          </p>
+          <p>
+            <span className="font-medium">Errors:</span> {summary.errors}
+          </p>
+          <p>
+            <span className="font-medium">Found values:</span> {summary.found_values.join(", ") || "None"}
+          </p>
+        </div>
+      )}
+
+      <p className="text-center text-sm">
         API documentation is available at <Link href="/docs" className="underline">/docs</Link>.
       </p>
     </main>


### PR DESCRIPTION
## Summary
- update `@netlify/plugin-nextjs`
- add a simple crawler form to the Next.js root page
- allow configuring API base URL and show crawl progress

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm run build` in `ui/`


------
https://chatgpt.com/codex/tasks/task_e_685648e6f6848322b30a8790e6cc0592